### PR TITLE
Adds data migration from old data model to new

### DIFF
--- a/DataCapturing/Model/CyfaceModel.xcdatamodeld/.xccurrentversion
+++ b/DataCapturing/Model/CyfaceModel.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>2.xcdatamodel</string>
+</dict>
+</plist>

--- a/DataCapturing/Model/CyfaceModel.xcdatamodeld/2.xcdatamodel/contents
+++ b/DataCapturing/Model/CyfaceModel.xcdatamodeld/2.xcdatamodel/contents
@@ -14,11 +14,12 @@
         <attribute name="timestamp" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <entity name="Measurement" representedClassName="MeasurementMO" syncable="YES">
+        <attribute name="context" attributeType="String" syncable="YES"/>
         <attribute name="identifier" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="synchronized" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="timestamp" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <relationship name="accelerations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Acceleration" syncable="YES"/>
-        <relationship name="geoLocations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GeoLocation" syncable="YES"/>
+        <relationship name="accelerations" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Acceleration" syncable="YES"/>
+        <relationship name="geoLocations" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="GeoLocation" syncable="YES"/>
     </entity>
     <elements>
         <element name="Acceleration" positionX="-56" positionY="-63" width="128" height="105"/>


### PR DESCRIPTION
Since we switched to RadVerS version we require a context for each measurement. In RadVerS this is work, leisure and shopping. In Cyface it is bicycle, car and motorbike. This was added to the data model without any data migration logic which is bad for the STADTRADELN app. This commit adds the data migration from the previous old data model without measurement context to the new one with the context.