### PR TITLE
Increase timeout for measurement loading to 10 s

### DIFF
--- a/DataCapturing/DataCapturingService.swift
+++ b/DataCapturing/DataCapturingService.swift
@@ -355,7 +355,7 @@ public class DataCapturingService: NSObject {
             }
             syncGroup.leave()
         }
-        guard syncGroup.wait(timeout: DispatchTime.now() + .seconds(2)) == .success else {
+        guard syncGroup.wait(timeout: DispatchTime.now() + .seconds(10)) == .success else {
             fatalError("DataCapturingService.loadMeasurement(withIdentifier: \(identifier)): Unable to load measurement!")
         }
         return ret


### PR DESCRIPTION
The timeout has been 2 seconds. This is obviously to small. In the next release we should make the timeout configurable. For now we just increase it to a more comfortable value and see what happens.