### PR TITLE
Change cleaning of location cache to create new

### DIFF
--- a/DataCapturing/DataCapturingService.swift
+++ b/DataCapturing/DataCapturingService.swift
@@ -538,9 +538,8 @@ public class DataCapturingService: NSObject {
             }
          }*/
         locationsCacheSynchronizationQueue.async(flags: .barrier) {
-            self.persistenceLayer.save(locations: self.locationsCache, toMeasurement: measurement) {
-                self.locationsCache.removeAll()
-            }
+            self.persistenceLayer.save(locations: self.locationsCache, toMeasurement: measurement)
+            self.locationsCache = [GeoLocation]()
          }
     }
 }

--- a/DataCapturing/Model/PersistenceLayer.swift
+++ b/DataCapturing/Model/PersistenceLayer.swift
@@ -250,7 +250,7 @@ public class PersistenceLayer {
      - toMeasurement: The measurement to store the `location` and `accelerations` to.
      - onFinished: The handler to call as soon as the database operation has finished.
      */
-    func save(locations: [GeoLocation], toMeasurement measurement: MeasurementEntity, onFinished handler: @escaping () -> Void) {
+    func save(locations: [GeoLocation], toMeasurement measurement: MeasurementEntity, onFinished handler: @escaping () -> Void = {}) {
         container.performBackgroundTask { context in
             let measurementIdentifier = measurement.identifier
             guard let measurement = self.load(measurementIdentifiedBy: measurementIdentifier, from: context) else {


### PR DESCRIPTION
Until now the same array was used over and over again, which caused problems due to write operations from multiple thread. Now the cache is recreated on every database synchronization, which should remove the possibility of multiple thread writing at the same time.