### PR TITLE
Set correct paused status after crash

### DIFF
--- a/DataCapturing/Capturing/DataCapturingService.swift
+++ b/DataCapturing/Capturing/DataCapturingService.swift
@@ -205,6 +205,7 @@ public class DataCapturingService: NSObject {
                 if let currentMeasurement = currentMeasurement {
                     try finish(measurement: currentMeasurement)
                 }
+                self.isPaused = false
             }
 
             let timestamp = DataCapturingService.currentTimeInMillisSince1970()


### PR DESCRIPTION
To recover the lifecycle after a crash, the app needs to set the paused status to false if starting new.