### PR TITLE
Provide event to notification on lifecycle events

### DIFF
--- a/DataCapturing.xcodeproj/project.pbxproj
+++ b/DataCapturing.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		3D1251D323584BE60082D961 /* SensorCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1251D223584BE60082D961 /* SensorCapturer.swift */; };
 		3D1505EC213E9F3A002994D2 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		3D1505EE213EA68D002994D2 /* DataCapturingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1505ED213EA68D002994D2 /* DataCapturingError.swift */; };
+		3D1C942F246ACCFB003A1145 /* TestDataCapturingEventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1C942E246ACCFA003A1145 /* TestDataCapturingEventHandler.swift */; };
 		3D1D9A87224BAA8B0053B1B7 /* CoreDataMigrationVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1D9A86224BAA8B0053B1B7 /* CoreDataMigrationVersion.swift */; };
 		3D1D9A89224BACF20053B1B7 /* CoreDataMigrationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1D9A88224BACF20053B1B7 /* CoreDataMigrationStep.swift */; };
 		3D1D9A8B224BB1CE0053B1B7 /* CoreDataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D1D9A8A224BB1CE0053B1B7 /* CoreDataMigrator.swift */; };
@@ -103,6 +104,7 @@
 		3D1251D223584BE60082D961 /* SensorCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCapturer.swift; sourceTree = "<group>"; };
 		3D1251D82358F36B0082D961 /* 9.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = 9.xcdatamodel; sourceTree = "<group>"; };
 		3D1505ED213EA68D002994D2 /* DataCapturingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataCapturingError.swift; sourceTree = "<group>"; };
+		3D1C942E246ACCFA003A1145 /* TestDataCapturingEventHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataCapturingEventHandler.swift; sourceTree = "<group>"; };
 		3D1D9A86224BAA8B0053B1B7 /* CoreDataMigrationVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataMigrationVersion.swift; sourceTree = "<group>"; };
 		3D1D9A88224BACF20053B1B7 /* CoreDataMigrationStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataMigrationStep.swift; sourceTree = "<group>"; };
 		3D1D9A8A224BB1CE0053B1B7 /* CoreDataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataMigrator.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 				3D1D9A8E224D28190053B1B7 /* DataSetCreator.swift */,
 				3D3A7DD12258E39B0019998A /* TestLocationManager.swift */,
 				3DBE27C523FA9E1D006E9A90 /* FakeMeasurement.swift */,
+				3D1C942E246ACCFA003A1145 /* TestDataCapturingEventHandler.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -657,6 +660,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DBE27C623FA9E1D006E9A90 /* FakeMeasurement.swift in Sources */,
+				3D1C942F246ACCFB003A1145 /* TestDataCapturingEventHandler.swift in Sources */,
 				3D8E5256223FDC8E004D7E2B /* DataMigrationTest.swift in Sources */,
 				3D0511E7204D622700967898 /* SerializationTest.swift in Sources */,
 				3D8E524D223EB240004D7E2B /* TestMotionManager.swift in Sources */,

--- a/DataCapturing/Capturing/DataCapturingEvent.swift
+++ b/DataCapturing/Capturing/DataCapturingEvent.swift
@@ -29,6 +29,7 @@ import Foundation
  case geoLocationAcquired
  case lowDiskSpace
  case serviceStarted
+ case servicePaused
  case serviceResumed
  case serviceStopped
  case synchronizationFinished
@@ -60,21 +61,31 @@ public enum DataCapturingEvent {
     /**
      Used to notify the client application of a successful start of the `DataCapturingService`.
 
-     - measurement: The device wide unique identifier of the measurement for which the service has started.
+     - measurement: The device wide unique identifier of the measurement for which the service has started
+     - event: The event stored for this service start
      */
-    case serviceStarted(measurement: Int64?)
+    case serviceStarted(measurement: Int64?, event: Event)
+    /**
+     Used to notify the client application of a successful pause of the `DataCapturingService`.
+
+     - measurement: The device wide unique identifier of the measurement for which the service has paused
+     - event: The event stored for this service pause
+     */
+    case servicePaused(measurement: Int64?, event: Event)
     /**
      Used to notify the client application of a successful resume of the `DataCapturingService`.
 
-     - measurement: The device wide unique identifier of the measurement for which the service has resumed.
+     - measurement: The device wide unique identifier of the measurement for which the service has resumed
+     - event: The event stored for this service resume
     */
-    case serviceResumed(measurement: Int64?)
+    case serviceResumed(measurement: Int64?, event: Event)
     /**
      Used to notify the client application of a successful stop of the `DataCapturingService`.
 
-     - measurement: The device wide unique identifier of the measurement for which the service has stopped.
+     - measurement: The device wide unique identifier of the measurement for which the service has stopped
+     - event: The event stored for this service stop
      */
-    case serviceStopped(measurement: Int64?)
+    case serviceStopped(measurement: Int64?, event: Event)
     /**
      Occurs if the `DataCapturingService` has finished synchronizing a measurement.
      This does not necessarily mean, that the synchronization was successful.

--- a/DataCapturingTests/Support/TestDataCapturingEventHandler.swift
+++ b/DataCapturingTests/Support/TestDataCapturingEventHandler.swift
@@ -1,0 +1,35 @@
+//
+//  TestDataCapturingEventHandler.swift
+//  DataCapturingTests
+//
+//  Created by Team Cyface on 12.05.20.
+//  Copyright © 2020 Cyface GmbH. All rights reserved.
+//
+
+import Foundation
+@testable import DataCapturing
+
+/**
+An event handler for `DataCapturingEvent` instances, collecting events in the order they occur during a test.
+
+ - Author: Klemens Muthmann
+ - Version: 1.0.0
+ */
+class TestDataCapturingEventHandler {
+    /// The captured event objects in chronological order
+    var capturedEvents = [DataCapturingEvent]()
+    /// The captured statuses in chronological order
+    var capturedStatuses = [Status]()
+
+    /**
+     A handler method for logging `DataCapturingEvent` instances and the corresponding `Status`.
+
+     - Parameters:
+            - event: The event to remember
+            - status: The status of the event
+     */
+    func handle(event: DataCapturingEvent, status: Status) {
+        capturedEvents.append(event)
+        capturedStatuses.append(status)
+    }
+}

--- a/DataCapturingTests/Support/TestDataCapturingService.swift
+++ b/DataCapturingTests/Support/TestDataCapturingService.swift
@@ -33,8 +33,8 @@ class TestDataCapturingService: DataCapturingService {
     /// The timer used to simulate location updates every second, like in the real app.
     var timer: DispatchSourceTimer?
 
-    override func startCapturing(savingEvery time: TimeInterval, for event: EventType) throws {
-        try super.startCapturing(savingEvery: time, for: event)
+    override func startCapturing(savingEvery time: TimeInterval, for event: EventType) throws -> Event? {
+        let event = try super.startCapturing(savingEvery: time, for: event)
         timer = DispatchSource.makeTimerSource()
         timer!.setEventHandler { [weak self] in
             guard let self = self else {
@@ -46,6 +46,7 @@ class TestDataCapturingService: DataCapturingService {
         }
         timer!.schedule(deadline: .now(), repeating: 1)
         timer!.resume()
+        return event
     }
 
     override func stopCapturing() {


### PR DESCRIPTION
This commit adds the created event object as a parameter to the handled event provided after one such event has finished. That way the code handling the event can react properly without the need to query the complete measurement.