### PR TITLE
Fail authentication on StaticAuthenticator if JWT token is an empty

### DIFF
--- a/DataCapturing/Source/Synchronization/StaticAuthenticator.swift
+++ b/DataCapturing/Source/Synchronization/StaticAuthenticator.swift
@@ -50,6 +50,9 @@ public class StaticAuthenticator: Authenticator {
 
     public func authenticate(onSuccess: (String) -> Void, onFailure: (Error) -> Void) {
         if let jwtToken = jwtToken {
+            if jwtToken.isEmpty {
+                onFailure(ServerConnection.ServerConnectionError.notAuthenticated("Provided JWT token was empty."))
+            }
             onSuccess(jwtToken)
         } else {
             onFailure(ServerConnection.ServerConnectionError.notAuthenticated("No JWT token provided for authentication."))


### PR DESCRIPTION
This change does not affect our App but it seems to be happening in client apps.