### PR TITLE
Add Chaos test for writing to database

### DIFF
--- a/DataCapturing/Source/Model/EventType.swift
+++ b/DataCapturing/Source/Model/EventType.swift
@@ -25,7 +25,7 @@ import Foundation
  - Version: 1.1.0
  - Since: 4.6.1
  */
-public enum EventType: Int16 {
+public enum EventType: Int16, CaseIterable {
     /// An event logged after the service has successfully started
     case lifecycleStart
     /// An event logged after the service has successfully paused

--- a/DataCapturing/Source/Persistence/PersistenceError.swift
+++ b/DataCapturing/Source/Persistence/PersistenceError.swift
@@ -72,6 +72,12 @@ extension PersistenceError: LocalizedError {
                 comment: ""
             )
             return errorMessage
+        case .missingTrack(let measurement):
+            let errorMessage = NSLocalizedString(
+                "de.cyface.error.PersistenceError.missingTrack",
+                value: "Encountered measurement %d without track to store data to!",
+                comment: "")
+            return String.localizedStringWithFormat(errorMessage, measurement.identifier)
         }
     }
 }

--- a/DataCapturing/Source/Persistence/PersistenceLayer.swift
+++ b/DataCapturing/Source/Persistence/PersistenceLayer.swift
@@ -261,7 +261,7 @@ public class PersistenceLayer {
             }
 
             guard let track = measurement.tracks.last else {
-                throw PersistenceError.inconsistentState
+                throw PersistenceError.missingTrack(measurement)
             }
             guard let trackObjectId = track.objectId else {
                 throw PersistenceError.nonPersistentTrackEncountered(track, measurement)
@@ -639,4 +639,6 @@ public enum PersistenceError: Error {
     case inconsistentState
     /// On trying to load a not yet synchronized `Measurement`. This is usually a `Measurement` with en `objectId` of `nil`.
     case unsynchronizedMeasurement(identifier: Int64)
+    /// If a measurement, which was expected to
+    case missingTrack(Measurement)
 }

--- a/DataCapturing/Tests/ChaosPersistenceTest.swift
+++ b/DataCapturing/Tests/ChaosPersistenceTest.swift
@@ -1,0 +1,247 @@
+//
+//  ChaosPersistenceTest.swift
+//  DataCapturing-Unit-Tests
+//
+//  Created by Klemens Muthmann on 20.02.23.
+//
+
+import XCTest
+import CoreData
+@testable import DataCapturing
+
+/**
+ Runs CoreData write operations in multiple parallel threads to make sure, that no concurrency issues arise.
+
+ - Author: Klemens Muthmann
+ - Version: 1.0.0
+ */
+class ChaosPersistenceTest: XCTestCase {
+    /// A `PersistenceLayer` used for testing.
+    var oocut: PersistenceLayer?
+    /// Some test data.
+    var fixture: DataCapturing.Measurement?
+
+    /// Create the object of the class under test as well as some test fixture.
+    override func setUp() {
+        do {
+            let coreDataManager = try CoreDataManager(storeType: NSInMemoryStoreType)
+            let bundle = Bundle(for: type(of: coreDataManager))
+            let expectation = expectation(description: "Setup finished")
+            coreDataManager.setup(bundle: bundle) { [weak self] error in
+                defer {
+                    expectation.fulfill()
+                }
+
+                if let error = error {
+                    XCTFail(error.localizedDescription)
+                    return
+                }
+
+                guard let self = self else {
+                    XCTFail("Test object was gone before initialization was complete!")
+                    return
+                }
+
+                let oocut = PersistenceLayer(onManager: coreDataManager)
+
+                do {
+                    var fixture = try oocut.createMeasurement(at: Int64(Date().timeIntervalSince1970*1000), inMode: "BICYCLE")
+                    try oocut.appendNewTrack(to: &fixture)
+                    try oocut.save(locations: [TestFixture.randomLocation(), TestFixture.randomLocation()], in: &fixture)
+                    try oocut.save(accelerations: [TestFixture.randomAcceleration(), TestFixture.randomAcceleration(), TestFixture.randomAcceleration()], in: &fixture)
+                    self.fixture = fixture
+                } catch {
+                    XCTFail(error.localizedDescription)
+                    return
+                }
+
+                self.oocut = oocut
+            }
+
+            waitForExpectations(timeout: 5) { error in
+                if let error = error {
+                    XCTFail(error.localizedDescription)
+                }
+            }
+        } catch {
+            XCTFail(error.localizedDescription)
+            return
+        }
+    }
+
+    /// Remove the object of the class under test as well as the test fixture after each test.
+    override func tearDown() {
+        oocut = nil
+        fixture = nil
+    }
+
+    /// Create a bunch of measurements in parrallel.
+    func testCreateMeasurementChaos() {
+        // Arrange
+        var identifier = [Int64]()
+        guard let oocut = oocut else {
+            XCTFail("Object of class under test was not properly initialized!")
+            return
+        }
+
+        // Act
+        chaosTest(executions: 1000) {
+            let createdMeasurement = try oocut.createMeasurement(at: Int64(Date().timeIntervalSince1970*1000), inMode: "BICYCLE")
+
+            // Assert
+            XCTAssertFalse(identifier.contains(createdMeasurement.identifier))
+            identifier.append(createdMeasurement.identifier)
+        }
+    }
+
+    /// Clean the fixture measurement a bunch of times in parallel.
+    func testCleanMeasurementChaos() {
+        // Arrange
+        guard let oocut = oocut else {
+            XCTFail("Object of class under test was not properly initialized!")
+            return
+        }
+        guard let fixture = fixture else {
+            XCTFail("Fixture was not properly initialized!")
+            return
+        }
+
+        chaosTest(executions: 1000) {
+            try oocut.clean(measurement: fixture.identifier)
+        }
+    }
+
+    /// Append tracks to the fixture in parallel.
+    func testAppendNewTrackChaos() throws {
+        // Arrange
+        guard let oocut = oocut else {
+            XCTFail("Object of class under test was not properly initialized!")
+            return
+        }
+        var measurement = try oocut.createMeasurement(at: Int64(Date().timeIntervalSince1970*1000), inMode: "BICYCLE")
+
+        // Act / Assert
+        chaosTest(executions: 1000) {
+            try oocut.appendNewTrack(to: &measurement)
+        }
+    }
+
+    /// This calls all the writing functions (except for delete) randomly in parallel.
+    func testTotalChaos() {
+        guard let oocut = oocut else {
+            XCTFail("Object of class under test was not properly initialized!")
+            return
+        }
+
+        guard let fixture = fixture else {
+            XCTFail("Test fixture was not properly initialized!")
+            return
+        }
+
+        var measurementsWithAtLeastOneTrack = Array<DataCapturing.Measurement>()
+        var measurements = Array<DataCapturing.Measurement>()
+        measurementsWithAtLeastOneTrack.append(fixture)
+        measurements.append(fixture)
+        chaosTest(executions: 5000) {
+            let commandIndex = Int.random(in: 0...3)
+            do {
+                if commandIndex == 0 {
+                    let createdMeasurement = try oocut.createMeasurement(at: Int64(Date().timeIntervalSince1970*1000), inMode: "BICYCLE")
+                } else if commandIndex == 1 {
+                    var randomMeasurement = self.randomMeasurement(from: measurementsWithAtLeastOneTrack)
+                    try oocut.appendNewTrack(to: &randomMeasurement)
+                    measurementsWithAtLeastOneTrack.append(randomMeasurement)
+                } else if commandIndex == 2 {
+                    var randomMeasurement = self.randomMeasurement(from: measurementsWithAtLeastOneTrack)
+                    try oocut.save(locations: [TestFixture.randomLocation(), TestFixture.randomLocation()], in: &randomMeasurement)
+                } else if commandIndex == 3 {
+                    var randomMeasurement = self.randomMeasurement(from: measurements)
+                    try oocut.clean(measurement: randomMeasurement.identifier)
+                } else if commandIndex == 4 {
+                    var randomMeasurement = self.randomMeasurement(from: measurements)
+                    let randomEventType = EventType.allCases.randomElement()!
+                    if randomEventType == .modalityTypeChange {
+                        let randomModality = ["CAR", "BICYCLE", "WALKING", "BUS", "TRAIN"].randomElement()!
+                        try oocut.createEvent(of: randomEventType, withValue: randomModality, parent: &randomMeasurement)
+                    } else {
+                        try oocut.createEvent(of: randomEventType, parent: &randomMeasurement)
+                    }
+                } else if commandIndex == 5 {
+                    var randomMeasurement = self.randomMeasurement(from: measurementsWithAtLeastOneTrack)
+                    try oocut.save(
+                        accelerations: [TestFixture.randomAcceleration(), TestFixture.randomAcceleration()],
+                        in: &randomMeasurement
+                    )
+                } else if commandIndex == 6 {
+                    var randomMeasurement = self.randomMeasurement(from: measurementsWithAtLeastOneTrack)
+                    randomMeasurement.synchronized = true
+                    _ = try oocut.save(measurement: randomMeasurement)
+                }
+            } catch {
+                throw ChaosTestError.wrappedError(commandIndex: commandIndex, error: error)
+            }
+        }
+    }
+
+    /// Provide a random measurement from an array of measurements
+    func randomMeasurement(from measurements: [DataCapturing.Measurement]) -> DataCapturing.Measurement {
+        return measurements[Int.random(in: 0..<measurements.count)]
+    }
+
+    /// This function calls the provided closure the number of times of `executions` in parallel with a random sleep time added before each call.
+    /// That way it tries to provoke threading issues with the code provided by the closure.
+    func chaosTest(executions: Int, closure: @escaping () throws -> ()) {
+        // Arrange
+        let group = DispatchGroup()
+
+        // Act
+        for _ in 0...executions {
+            group.enter()
+
+            DispatchQueue.global().async {
+                defer {
+                    group.leave()
+                }
+
+                let sleepVal = UInt32.random(in: 0...999)
+                usleep(sleepVal)
+                do {
+                    try closure()
+                } catch {
+                    return XCTFail("Execution failed due to: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        let result = group.wait(timeout: DispatchTime.now() + 40)
+
+        // Assert
+        XCTAssert(result == .success)
+    }
+}
+
+/**
+  Errors thrown by the chaos test.
+
+ - Author: Klemens Muthmann
+ - Version: 1.0.0
+ */
+enum ChaosTestError: Error {
+    /// An error wrapping another error, thrown by the closure called by the chaos test.
+    case wrappedError(commandIndex: Int, error: Error)
+}
+
+extension ChaosTestError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .wrappedError(commandIndex: let commandIndex, error: let error):
+            let message = NSLocalizedString(
+                "de.cyface.ChaosTestError.wrappedError",
+                value: """
+                Chaos Test failed on command %d due to %@.
+                """,
+                comment: "Explain to the user on which command the test has failed and why.")
+            return String.localizedStringWithFormat(message, commandIndex, error.localizedDescription)
+        }
+    }
+}

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		AA11963F2993A688008161C4 /* CoreDataMigrationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA11963E2993A688008161C4 /* CoreDataMigrationError.swift */; };
 		AA4BFF1F297986ED005233E8 /* V11DatabaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4BFF1E297986ED005233E8 /* V11DatabaseTest.swift */; };
 		AA4BFF21297988BF005233E8 /* MeasurementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4BFF20297988BF005233E8 /* MeasurementTest.swift */; };
+		AACEFE6D29A381CB004D0AFA /* ChaosPersistenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACEFE6C29A381CB004D0AFA /* ChaosPersistenceTest.swift */; };
 		AAD6295E299A227A0084B13D /* V2TestData.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = AAD6294F299A227A0084B13D /* V2TestData.sqlite */; };
 		AAD6295F299A227A0084B13D /* V5TestData.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = AAD62950299A227A0084B13D /* V5TestData.sqlite */; };
 		AAD62960299A227A0084B13D /* V4TestData.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = AAD62951299A227A0084B13D /* V4TestData.sqlite */; };
@@ -678,6 +679,7 @@
 		AA3119387680A84BF2842BF723502FF7 /* Charts-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Charts-umbrella.h"; sourceTree = "<group>"; };
 		AA4BFF1E297986ED005233E8 /* V11DatabaseTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = V11DatabaseTest.swift; path = DataCapturing/Tests/V11DatabaseTest.swift; sourceTree = "<group>"; };
 		AA4BFF20297988BF005233E8 /* MeasurementTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MeasurementTest.swift; path = DataCapturing/Tests/MeasurementTest.swift; sourceTree = "<group>"; };
+		AACEFE6C29A381CB004D0AFA /* ChaosPersistenceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ChaosPersistenceTest.swift; path = DataCapturing/Tests/ChaosPersistenceTest.swift; sourceTree = "<group>"; };
 		AAD6294F299A227A0084B13D /* V2TestData.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = V2TestData.sqlite; sourceTree = "<group>"; };
 		AAD62950299A227A0084B13D /* V5TestData.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = V5TestData.sqlite; sourceTree = "<group>"; };
 		AAD62951299A227A0084B13D /* V4TestData.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = V4TestData.sqlite; sourceTree = "<group>"; };
@@ -1381,6 +1383,7 @@
 				A6089A19485A5E314B7336B9877083C5 /* TrackCleanerTest.swift */,
 				AA4BFF1E297986ED005233E8 /* V11DatabaseTest.swift */,
 				AA4BFF20297988BF005233E8 /* MeasurementTest.swift */,
+				AACEFE6C29A381CB004D0AFA /* ChaosPersistenceTest.swift */,
 				11ECD5C1A2FA94BD3B12EE8BF1059510 /* Support */,
 			);
 			name = Tests;
@@ -2231,6 +2234,7 @@
 				879551CC6520878837197E03ADB54F71 /* SerializationTest.swift in Sources */,
 				02614CCFB8AC43D4E6E793D1A89D74FA /* ServerConnectionTest.swift in Sources */,
 				7F8C20A7CD097DB2EE86A6CEC22346B8 /* TestDataCapturingEventHandler.swift in Sources */,
+				AACEFE6D29A381CB004D0AFA /* ChaosPersistenceTest.swift in Sources */,
 				4782F3185E00E2060D3B581E5A73B851 /* TestDataCapturingService.swift in Sources */,
 				2089DFAFB482ABE68EFD31AC24CF27B6 /* TestFixture.swift in Sources */,
 				CCDA0713496420D577B4796C7A4974AA /* TestLocationManager.swift in Sources */,


### PR DESCRIPTION
This test runs write operations on the database from at least a thousand threads in parallel and tries to provoke multi threading issues. If it is not flaky, the systems seems to work fine.