### PR TITLE
Add new finished event after data storage finished

### DIFF
--- a/DataCapturing/Package.swift
+++ b/DataCapturing/Package.swift
@@ -61,7 +61,6 @@ let package = Package(
             ],
             exclude: ["Support/Info.plist"],
             resources: [
-                .process("Synchronization/Upload/Background/SessionRegistry.xcdatamodeld"),
                 .process("Model/Migrations/V3toV4/V3toV4.xcmappingmodel"),
                 .process("Model/CyfaceModel.xcdatamodeld"),
                 .process("Model/Migrations/V10toV11/V10toV11.xcmappingmodel"),

--- a/DataCapturing/Sources/DataCapturing/Capturing/Measurement.swift
+++ b/DataCapturing/Sources/DataCapturing/Capturing/Measurement.swift
@@ -219,10 +219,10 @@ Starting data capturing on paused service. Finishing paused measurements and sta
 
             // Inform about stopped event
             stopCapturing()
-            messagesSubject.send(completion: .finished)
             isPaused = false
 
             messagesSubject.send(.stopped(timestamp: Date()))
+            messagesSubject.send(completion: .finished)
         }
     }
 

--- a/DataCapturing/Sources/DataCapturing/Capturing/Measurement.swift
+++ b/DataCapturing/Sources/DataCapturing/Capturing/Measurement.swift
@@ -35,8 +35,9 @@ This protocol defines a measurements data together with its lifecycle during dat
  - Since: 12.0.0
  */
 public protocol Measurement {
+    // TODO: It should not be possible to send messages via this variable. So this should be a publisher instead of a PasstroughSubject
     /// A combine subject used to receive messages during data capturing and forwarding them, to whoever wants to listen.
-    var measurementMessages: PassthroughSubject<Message, Never> { get }
+    var measurementMessages: AnyPublisher<Message, Never> { get }
     /// A flag to get information about whether this measurement is currently running (`true`) or not (`false`).
     var isRunning: Bool { get }
     /// A flag to get information about whether this measurement is currently paused (`true`) or not (`false`).
@@ -75,7 +76,6 @@ public class MeasurementImpl {
     /// `true` if data capturing was running but is currently paused; `false` otherwise.
     public var isPaused:Bool
 
-    // TODO: This should probably be carried out using an actor: See the talk "Protect mutable state with Swift actors" from WWDC 2021
     /// The background queue used to capture data.
     private let capturingQueue: DispatchQueue
 
@@ -85,9 +85,8 @@ public class MeasurementImpl {
     private let locationCapturer: LocationCapturer
 
     // TODO: Switch to Combine --> Make this a publisher on its own. Will have to read up on how to achieve this.
-    public var measurementMessages: PassthroughSubject<Message, Never>
+    public var messagesSubject: PassthroughSubject<Message, Never>
 
-    // TODO: This should probably be carried out using an actor: See the talk "Protect mutable state with Swift actors" from WWDC 2021
     /**
      A queue used to synchronize calls to the lifecycle methods `start`, `pause`, `resume` and `stop`.
      Using such a queue prevents successiv calls to these methods to interrupt each other.
@@ -115,7 +114,6 @@ public class MeasurementImpl {
             manager.activityType = .other
             manager.showsBackgroundLocationIndicator = true
             manager.distanceFilter = kCLDistanceFilterNone
-            //manager.requestAlwaysAuthorization()
             return manager
         }
     ) {
@@ -123,7 +121,7 @@ public class MeasurementImpl {
         self.lifecycleQueue = DispatchQueue(label: "lifecycle")
         self.sensorCapturer = SensorCapturer(capturingQueue: capturingQueue)
         self.locationCapturer = LocationCapturer(lifecycleQueue: lifecycleQueue, locationManagerFactory: locationManagerFactory)
-        measurementMessages = PassthroughSubject<Message, Never>()
+        messagesSubject = PassthroughSubject<Message, Never>()
 
         self.isRunning = false
         self.isPaused = false
@@ -153,7 +151,7 @@ public class MeasurementImpl {
 
         messageCancellable = locationCapturer.start().receive(on: lifecycleQueue).merge(
             with: sensorCapturer.start()
-        ).subscribe(measurementMessages)
+        ).subscribe(messagesSubject)
 
         self.isRunning = true
     }
@@ -175,6 +173,10 @@ public class MeasurementImpl {
 // MARK: - Measurement
 
 extension MeasurementImpl: Measurement {
+    public var measurementMessages: AnyPublisher<Message, Never> {
+        return messagesSubject.eraseToAnyPublisher()
+    }
+    
     /**
      Starts the capturing process.
 
@@ -195,7 +197,7 @@ Starting data capturing on paused service. Finishing paused measurements and sta
             }
 
             try startCapturing()
-            measurementMessages.send(.started(timestamp: Date()))
+            messagesSubject.send(.started(timestamp: Date()))
         }
     }
 
@@ -217,9 +219,10 @@ Starting data capturing on paused service. Finishing paused measurements and sta
 
             // Inform about stopped event
             stopCapturing()
+            messagesSubject.send(completion: .finished)
             isPaused = false
 
-            measurementMessages.send(.stopped(timestamp: Date()))
+            messagesSubject.send(.stopped(timestamp: Date()))
         }
     }
 
@@ -242,7 +245,7 @@ Starting data capturing on paused service. Finishing paused measurements and sta
             stopCapturing()
             isPaused = true
 
-            measurementMessages.send(.paused(timestamp: Date()))
+            messagesSubject.send(.paused(timestamp: Date()))
         }
     }
 
@@ -267,7 +270,7 @@ Starting data capturing on paused service. Finishing paused measurements and sta
             isPaused = false
             isRunning = true
 
-            measurementMessages.send(.resumed(timestamp: Date()))
+            messagesSubject.send(.resumed(timestamp: Date()))
         }
     }
 
@@ -279,7 +282,7 @@ Starting data capturing on paused service. Finishing paused measurements and sta
      */
     public func changeModality(to modality: String) {
         lifecycleQueue.sync {
-            measurementMessages.send(.modalityChanged(to: modality))
+            messagesSubject.send(.modalityChanged(to: modality))
         }
     }
 }

--- a/DataCapturing/Sources/DataCapturing/Capturing/Measurement.swift
+++ b/DataCapturing/Sources/DataCapturing/Capturing/Measurement.swift
@@ -127,18 +127,6 @@ public class MeasurementImpl {
 
         self.isRunning = false
         self.isPaused = false
-
-        finishedEventCancellable = measurementMessages.filter {
-            switch $0 {
-            case .finished(timestamp: _):
-                return true
-            default:
-                return false
-            }
-        }.sink {[weak self] _ in
-            self?.measurementMessages.send(completion: .finished)
-            self?.finishedEventCancellable = nil
-        }
     }
 
 

--- a/DataCapturing/Sources/DataCapturing/Capturing/Model/Message.swift
+++ b/DataCapturing/Sources/DataCapturing/Capturing/Model/Message.swift
@@ -43,6 +43,8 @@ public enum Message: CustomStringConvertible {
             return "Started measurement at \(time)"
         case .stopped(let time):
             return "Stopped measurement at \(time)"
+        case .finished(let time):
+            return "Finished measurement at \(time)"
         case .paused(let time):
             return "Paused measurement at \(time)"
         case .resumed(let time):
@@ -69,11 +71,51 @@ public enum Message: CustomStringConvertible {
     /// The message sent if a new direction was captured.
     case capturedDirection(SensorValue)
     case started(timestamp: Date)
+    /// Sent after all sensor have stopped capturing data.
     case stopped(timestamp: Date)
+    /// A message sent after a measurement was successfully stopped and persistet to permanent storage.
+    case finished(timestamp: Date)
     case paused(timestamp: Date)
     case resumed(timestamp: Date)
     case hasFix
     case fixLost
     case modalityChanged(to: String)
     case receivedNothingYet
+}
+
+extension Message: Equatable {
+    public static func == (lhs: Message, rhs: Message) -> Bool {
+        switch (lhs, rhs) {
+        case (.capturedLocation(let geoLocationLhs), .capturedLocation(let geoLocationRhs)):
+            return geoLocationLhs == geoLocationRhs
+        case (.capturedAltitude(let altitudeLhs), .capturedAltitude(let altitudeRhs)):
+            return altitudeLhs == altitudeRhs
+        case (.capturedAcceleration(let sensorValueLhs), .capturedAcceleration(let sensorValueRhs)):
+            return sensorValueLhs == sensorValueRhs
+        case (.capturedRotation(let sensorValueLhs), .capturedRotation(let sensorValueRhs)):
+            return sensorValueLhs == sensorValueRhs
+        case (.capturedDirection(let sensorValueLhs), .capturedDirection(let sensorValueRhs)):
+            return sensorValueLhs == sensorValueRhs
+        case (.started(let timestampLhs), .started(let timestampRhs)):
+            return timestampLhs == timestampRhs
+        case (.stopped(let timestampLhs), .stopped(let timestampRhs)):
+            return timestampLhs == timestampRhs
+        case (.finished(let timestampLhs), .finished(let timestampRhs)):
+            return timestampLhs == timestampRhs
+        case (.paused(let timestampLhs), .paused(let timestampRhs)):
+            return timestampLhs == timestampRhs
+        case (.resumed(let timestampLhs), .resumed(let timestampRhs)):
+            return timestampLhs == timestampRhs
+        case (.hasFix, .hasFix):
+            return true
+        case (.fixLost, .fixLost):
+            return true
+        case (.modalityChanged(let toLhs), .modalityChanged(to: let toRhs)):
+            return toLhs == toRhs
+        case (.receivedNothingYet, .receivedNothingYet):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/DataCapturing/Sources/DataCapturing/Capturing/Model/Message.swift
+++ b/DataCapturing/Sources/DataCapturing/Capturing/Model/Message.swift
@@ -43,8 +43,6 @@ public enum Message: CustomStringConvertible {
             return "Started measurement at \(time)"
         case .stopped(let time):
             return "Stopped measurement at \(time)"
-        case .finished(let time):
-            return "Finished measurement at \(time)"
         case .paused(let time):
             return "Paused measurement at \(time)"
         case .resumed(let time):
@@ -73,8 +71,6 @@ public enum Message: CustomStringConvertible {
     case started(timestamp: Date)
     /// Sent after all sensor have stopped capturing data.
     case stopped(timestamp: Date)
-    /// A message sent after a measurement was successfully stopped and persistet to permanent storage.
-    case finished(timestamp: Date)
     case paused(timestamp: Date)
     case resumed(timestamp: Date)
     case hasFix
@@ -99,8 +95,6 @@ extension Message: Equatable {
         case (.started(let timestampLhs), .started(let timestampRhs)):
             return timestampLhs == timestampRhs
         case (.stopped(let timestampLhs), .stopped(let timestampRhs)):
-            return timestampLhs == timestampRhs
-        case (.finished(let timestampLhs), .finished(let timestampRhs)):
             return timestampLhs == timestampRhs
         case (.paused(let timestampLhs), .paused(let timestampRhs)):
             return timestampLhs == timestampRhs

--- a/DataCapturing/Sources/DataCapturing/Model/Altitude.swift
+++ b/DataCapturing/Sources/DataCapturing/Model/Altitude.swift
@@ -24,6 +24,7 @@ import CoreData
  A struct to wrap all the information associated with a measured altitude provided by an altimeter.
 
  - Author: Klemens Muthmann
+ - version: 1.0.0
  */
 public class Altitude: CustomStringConvertible {
     /// The relative altitude change since the last measured value, in meters.
@@ -45,5 +46,17 @@ public class Altitude: CustomStringConvertible {
         self.relativeAltitude = relativeAltitude
         self.pressure = pressure
         self.time = time
+    }
+}
+
+extension Altitude: Equatable {
+    public static func == (lhs: Altitude, rhs: Altitude) -> Bool {
+        if lhs===rhs {
+            return true
+        } else {
+            return lhs.relativeAltitude.equal(rhs.relativeAltitude, precise: 3) &&
+            lhs.pressure.equal(rhs.pressure, precise: 3) &&
+            lhs.time == rhs.time
+        }
     }
 }

--- a/DataCapturing/Sources/DataCapturing/Model/Double.swift
+++ b/DataCapturing/Sources/DataCapturing/Model/Double.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  
+//
+//  Created by Klemens Muthmann on 18.03.24.
+//
+
+import Foundation
+
+public extension Double {
+    public func equal(_ value: Double, precise: Int) -> Bool {
+        let denominator: Double = pow(10.0, Double(precise))
+        let maxDiff: Double = 1 / denominator
+        let realDiff: Double = self - value
+
+        if fabs(realDiff) <= maxDiff {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/DataCapturing/Sources/DataCapturing/Model/FinishedMeasurement.swift
+++ b/DataCapturing/Sources/DataCapturing/Model/FinishedMeasurement.swift
@@ -74,7 +74,7 @@ public class FinishedMeasurement: Hashable, Equatable {
      - parameter managedObject: The managed CoreData object to initialize this `Measurement` from.
      - throws: `InconstantData.locationOrderViolation` if the timestamps of the locations in this measurement are not strongly monotonically increasing.
      */
-    convenience init(managedObject: MeasurementMO) throws {
+    public convenience init(managedObject: MeasurementMO) throws {
         let accelerationFile = SensorValueFile(fileType: .accelerationValueType, qualifier: String(managedObject.unsignedIdentifier))
         let directionFile = SensorValueFile(fileType: .directionValueType, qualifier: String(managedObject.unsignedIdentifier))
         let rotationFile = SensorValueFile(fileType: .rotationValueType, qualifier: String(managedObject.unsignedIdentifier))

--- a/DataCapturing/Sources/DataCapturing/Model/GeoLocation.swift
+++ b/DataCapturing/Sources/DataCapturing/Model/GeoLocation.swift
@@ -139,18 +139,3 @@ extension GeoLocation: Equatable {
         }
     }
 }
-
-// TODO: Move this to Double.swift
-public extension Double {
-    public func equal(_ value: Double, precise: Int) -> Bool {
-        let denominator: Double = pow(10.0, Double(precise))
-        let maxDiff: Double = 1 / denominator
-        let realDiff: Double = self - value
-
-        if fabs(realDiff) <= maxDiff {
-            return true
-        } else {
-            return false
-        }
-    }
-}

--- a/DataCapturing/Sources/DataCapturing/Model/GeoLocation.swift
+++ b/DataCapturing/Sources/DataCapturing/Model/GeoLocation.swift
@@ -123,3 +123,34 @@ public class GeoLocation: CustomStringConvertible {
         return distance(from: CLLocation(latitude: previousLocation.latitude, longitude: previousLocation.longitude))
     }
 }
+
+extension GeoLocation: Equatable {
+    public static func == (lhs: GeoLocation, rhs: GeoLocation) -> Bool {
+        if lhs === rhs {
+            return true
+        } else {
+            return lhs.latitude.equal(rhs.latitude, precise: 6) && 
+            lhs.longitude.equal(rhs.longitude, precise: 6) &&
+            lhs.speed.equal(rhs.speed, precise: 2) &&
+            lhs.accuracy.equal(rhs.accuracy, precise: 3) &&
+            lhs.time == rhs.time &&
+            lhs.altitude.equal(rhs.altitude, precise: 3) &&
+            lhs.verticalAccuracy.equal(rhs.verticalAccuracy, precise: 3)
+        }
+    }
+}
+
+// TODO: Move this to Double.swift
+public extension Double {
+    public func equal(_ value: Double, precise: Int) -> Bool {
+        let denominator: Double = pow(10.0, Double(precise))
+        let maxDiff: Double = 1 / denominator
+        let realDiff: Double = self - value
+
+        if fabs(realDiff) <= maxDiff {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/DataCapturing/Sources/DataCapturing/Persistence/CapturedDataStorage.swift
+++ b/DataCapturing/Sources/DataCapturing/Persistence/CapturedDataStorage.swift
@@ -120,15 +120,15 @@ public class CapturedCoreDataStorage<SVFF: SensorValueFileFactory> where SVFF.Se
         try self.dataStoreStack.wrapInContext { context in
             let measurementMo = try self.load(measurement: identifier, from: context)
 
-            let accelerationsFile = self?.sensorValueFileFactory.create(
+            let accelerationsFile = self.sensorValueFileFactory.create(
                  fileType: SensorValueFileType.accelerationValueType,
                  qualifier: String(measurementMo.unsignedIdentifier)
             )
-            let rotationsFile = self?.sensorValueFileFactory.create(
+            let rotationsFile = self.sensorValueFileFactory.create(
                  fileType: SensorValueFileType.rotationValueType,
                  qualifier: String(measurementMo.unsignedIdentifier)
             )
-            let directionsFile = self?.sensorValueFileFactory.create(
+            let directionsFile = self.sensorValueFileFactory.create(
                 fileType: SensorValueFileType.directionValueType,
                 qualifier: String(measurementMo.unsignedIdentifier)
             )
@@ -176,7 +176,7 @@ public class CapturedCoreDataStorage<SVFF: SensorValueFileFactory> where SVFF.Se
         }
     }
 
-    private func store(_ value: SensorValue, to file: SensorValueFile) throws {
+    private func store<SVF: FileSupport>(_ value: SensorValue, to file: SVF) throws where SVF.Serializable == SVFF.Serializable {
         do {
             _ = try file.write(serializable: [value])
         } catch {

--- a/DataCapturing/Sources/DataCapturing/Persistence/DataStoreStack.swift
+++ b/DataCapturing/Sources/DataCapturing/Persistence/DataStoreStack.swift
@@ -43,13 +43,7 @@ public protocol DataStoreStack {
     ///
     /// This method must be called shortly after initialization and before any other interaction with a newly created `DataStoreStack`.
     func setup() async throws
-    /// Provide an underlaying ``PersistenceLayer``.
-    ///
-    /// This method is only here for backwards compatibility.
-    /// `PersistenceLayer` is scheduled to die pretty soon.
-    @available(*, deprecated, message: "PersistenceLayer should not be used any longer. Please write your own data interaction code using `wrapInContext` and `wrapInContextReturn`.")
-    func persistenceLayer() -> PersistenceLayer
-    /// This checks if a measurement with that identifier already exists and generates a new identifier until it finds one with no corresponding measurement. 
+    /// This checks if a measurement with that identifier already exists and generates a new identifier until it finds one with no corresponding measurement.
     /// This is required to handle legacy data and installations, that still have measurements with falsely generated data.
     func nextValidIdentifier() throws -> UInt64
 }
@@ -149,10 +143,6 @@ public class CoreDataStack: DataStoreStack {
                 }
             }
         }
-    }
-
-    public func persistenceLayer() -> PersistenceLayer {
-        return CoreDataPersistenceLayer(onManager: self)
     }
 
     /// Load the specified `NSManagedObjectModel` from disk.

--- a/DataCapturing/Sources/DataCapturing/Persistence/SensorValueFileFactory.swift
+++ b/DataCapturing/Sources/DataCapturing/Persistence/SensorValueFileFactory.swift
@@ -48,10 +48,6 @@ public struct DefaultSensorValueFileFactory: SensorValueFileFactory {
     
     public typealias FileType = SensorValueFile
 
-    //public typealias Serializable = SensorValue
-
-    //public typealias SpecificSerializer = SensorValueSerializer
-
     public init() {
         // Nothing to do here.
     }

--- a/DataCapturing/Sources/DataCapturing/Synchronization/Upload/Default/DefaultUploadProcess.swift
+++ b/DataCapturing/Sources/DataCapturing/Synchronization/Upload/Default/DefaultUploadProcess.swift
@@ -26,6 +26,9 @@ import Combine
 
  It orchestrates the different requests required by the Cyface Upload Protocol.
 
+ Information about the current upload are distributed using the *Combine* Publisher ``DefaultUploadProcess/uploadStatus``.
+ For possible events see ``UploadStatusType``.
+
  - author: Klemens Muthmann
  - version: 1.0.0
  */

--- a/RFR-App/RFR.xcodeproj/project.pbxproj
+++ b/RFR-App/RFR.xcodeproj/project.pbxproj
@@ -752,7 +752,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.4;
+				MARKETING_VERSION = 3.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.RFR;
 				PRODUCT_NAME = "Ready for Robots";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -875,7 +875,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.4;
+				MARKETING_VERSION = 3.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.RFR.staging;
 				PRODUCT_NAME = "Ready for Robots Staging";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -992,7 +992,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.4;
+				MARKETING_VERSION = 3.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.RFR.staging;
 				PRODUCT_NAME = "Ready for Robots Staging";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1109,7 +1109,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.4;
+				MARKETING_VERSION = 3.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.RFR;
 				PRODUCT_NAME = "Ready for Robots";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1734,7 +1734,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.4;
+				MARKETING_VERSION = 3.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.RFR.dev;
 				PRODUCT_NAME = "Ready for Robots Development";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1772,7 +1772,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.4;
+				MARKETING_VERSION = 3.1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = de.cyface.RFR.dev;
 				PRODUCT_NAME = "Ready for Robots Development";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/RFR-App/RFR/Measurements/Measurement.swift
+++ b/RFR-App/RFR/Measurements/Measurement.swift
@@ -209,10 +209,11 @@ enum SynchronizationState {
     /// Convert a database `MeasurementMO` to its `SynchronizationState`
     static func from(measurement: MeasurementMO) -> SynchronizationState {
         let request = UploadSession.fetchRequest()
-        request.predicate = NSPredicate(format: "measurement.identifier=%d", measurement.identifier)
+        request.predicate = NSPredicate(format: "measurement=%@", measurement)
         request.fetchLimit = 1
         do {
-            if try request.execute().first != nil {
+            let sessions = try request.execute()
+            if !sessions.isEmpty {
                 return .synchronizing
             } else if measurement.synchronized {
                 return .synchronized

--- a/RFR-App/RFR/ViewModel/DataCapturingViewModel.swift
+++ b/RFR-App/RFR/ViewModel/DataCapturingViewModel.swift
@@ -38,7 +38,7 @@ class DataCapturingViewModel: ObservableObject {
     let measurementsViewModel: MeasurementsViewModel
     /// The view model used to handle measurement synchronization.
     let syncViewModel: SynchronizationViewModel
-    // TODO: All of this only concerns the `SynchronizationViewModel` and thus should only appear there.
+    // TODO: All of this only concerns the `SynchronizationViewModel` and thus should only appear there. --> Actually this class seems to have become unnecessary. Putting stuff together should happen in the AppModel only. Further down only dependency injection should be necessary.
     /// The authenticator used to authenticate for data uploads
     let authenticator: Authenticator
 
@@ -59,7 +59,7 @@ class DataCapturingViewModel: ObservableObject {
             dataStoreStack: dataStoreStack,
             uploadPublisher: syncViewModel.uploadStatusPublisher
         )
-        measurementsViewModel.subscribe(to: liveViewModel.$message)
+        measurementsViewModel.subscribe(to: liveViewModel.$finishedMessages)
         self.dataStoreStack = dataStoreStack
         try dataStoreStack.wrapInContext { context in
             let request = MeasurementMO.fetchRequest()


### PR DESCRIPTION
This is necessary, since now when the stopped event is received by the app, the measurement inside the database is not necessarily stopped and thus will not be eligeble for data synchronization.