### PR TITLE
fix/STAD-615_Serialization-Performance

### DIFF
--- a/DataCapturing/Sources/DataCapturing/Model/FinishedMeasurement.swift
+++ b/DataCapturing/Sources/DataCapturing/Model/FinishedMeasurement.swift
@@ -28,8 +28,6 @@ import OSLog
  A `Measurement` can be synchronized to a Cyface server via an instance of `Synchronizer`.
 
  - Author: Klemens Muthmann
- - Version: 2.0.0
- - since: 11.0.0
  */
 public class FinishedMeasurement: Hashable, Equatable {
     /// A device wide unique identifier for this measurement. Usually set by incrementing a counter.
@@ -75,9 +73,19 @@ public class FinishedMeasurement: Hashable, Equatable {
      - throws: `InconstantData.locationOrderViolation` if the timestamps of the locations in this measurement are not strongly monotonically increasing.
      */
     public convenience init(managedObject: MeasurementMO) throws {
-        let accelerationFile = SensorValueFile(fileType: .accelerationValueType, qualifier: String(managedObject.unsignedIdentifier))
-        let directionFile = SensorValueFile(fileType: .directionValueType, qualifier: String(managedObject.unsignedIdentifier))
-        let rotationFile = SensorValueFile(fileType: .rotationValueType, qualifier: String(managedObject.unsignedIdentifier))
+        let sensorValueFileFactory = DefaultSensorValueFileFactory()
+        let accelerationFile = try sensorValueFileFactory.create(
+            fileType: .accelerationValueType,
+            qualifier: String(managedObject.unsignedIdentifier)
+        )
+        let directionFile = try sensorValueFileFactory.create(
+            fileType: .directionValueType,
+            qualifier: String(managedObject.unsignedIdentifier)
+        )
+        let rotationFile = try sensorValueFileFactory.create(
+            fileType: .rotationValueType,
+            qualifier: String(managedObject.unsignedIdentifier)
+        )
 
         self.init(
             identifier: managedObject.unsignedIdentifier,

--- a/DataCapturing/Sources/DataCapturing/Persistence/SensorValueFileFactory.swift
+++ b/DataCapturing/Sources/DataCapturing/Persistence/SensorValueFileFactory.swift
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with the Cyface SDK for iOS. If not, see <http://www.gnu.org/licenses/>.
  */
+import Foundation
 
 /**
  A factory to externalize the creation of ``SensorValueFile`` instances.
@@ -25,37 +26,64 @@
  This can be used if different formats are required or the actual file is mocked for testing.
 
  - Author: Klemens Muthmann
- - Version: 1.0.0
- - Since: 12.0.0
  */
 public protocol SensorValueFileFactory {
+    /// The type of object to serialize in the files created from this factory.
     associatedtype Serializable
+    /// The serializer for the provided `Serializable`.
     associatedtype SpecificSerializer
+    /// The type of objects this factory creates.
     associatedtype FileType: FileSupport where FileType.Serializable == Serializable, FileType.SpecificSerializer == SpecificSerializer
     /// Create the actual file for a certain type
-    func create(fileType: SensorValueFileType, qualifier: String) -> FileType
+    func create(fileType: SensorValueFileType, qualifier: String) throws -> FileType
+}
+
+// MARK: - Implementation
+extension SensorValueFileFactory {
+    /// The root path used to store data via this app. This is in global scope, so it gets initialized at application start, since finding the location is a computation heavy operation.
+    func rootPath() throws -> URL {
+        let root = "Application Support"
+        let measurementDirectory = "measurements"
+        let fileManager = FileManager.default
+        let libraryDirectory = FileManager.SearchPathDirectory.libraryDirectory
+        let libraryDirectoryUrl = try fileManager.url(for: libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+
+        let measurementUrl = libraryDirectoryUrl
+            .appendingPathComponent(root)
+            .appendingPathComponent(measurementDirectory)
+        try fileManager.createDirectory(at: measurementUrl, withIntermediateDirectories: true)
+        return measurementUrl
+    }
 }
 
 /**
  Create the default ``SensorValueFile`` required by a recent Cyface Data Collector processing the Protobuf format and using the Google Media Upload Protocol.
 
  - Author: Klemens Muthmann
- - Version: 1.0.0
- - Since: 12.0.0
  */
 public struct DefaultSensorValueFileFactory: SensorValueFileFactory {
+    /// This factory is used to create files storing arrays of ``SensorValue``.
     public typealias Serializable = [SensorValue]
 
+    /// This factory creates files that serialize data using a ``SensorValueSerializer``.
     public typealias SpecificSerializer = SensorValueSerializer
     
+    /// This factory creates ``SensorValueFile``.
     public typealias FileType = SensorValueFile
 
+    // MARK: - Initializers
+    /// Create a new instance of this struct.
     public init() {
         // Nothing to do here.
     }
 
-    public func create(fileType: SensorValueFileType, qualifier: String) -> SensorValueFile {
-        return SensorValueFile(
+    /// Create a new ``SensorValueFile``.
+    ///
+    /// - Parameter qualifier: Used to make the file unique and distinguishable from other files storing the same type of data. Usually this is the measurement identifier.
+    /// - Parameter fileType: The type of ``SensorValue`` to store.
+    public func create(fileType: SensorValueFileType, qualifier: String) throws -> SensorValueFile {
+        return try SensorValueFile(
+            rootPath: rootPath(),
             fileType: SensorValueFileType.accelerationValueType,
             qualifier: qualifier
         )

--- a/DataCapturing/Sources/DataCapturing/Synchronization/Upload/ServerConnectionError.swift
+++ b/DataCapturing/Sources/DataCapturing/Synchronization/Upload/ServerConnectionError.swift
@@ -23,8 +23,6 @@ import Foundation
  A structure encapsulating errors used by server connections.
 
  - Author: Klemens Muthmann
- - Version: 6.0.0
- - Since: 1.0.0
  */
 public enum ServerConnectionError: Error {
     /// If authentication was carried out but was not successful. The username of the failed authentication attempt is provided as a parameter.


### PR DESCRIPTION
This avoids creating the root storage path during storage of each sensor value. Without this our app is unable to run for example on iPhone 7.